### PR TITLE
feat: create user with role by admin

### DIFF
--- a/app/core/security/jwt_middleware.py
+++ b/app/core/security/jwt_middleware.py
@@ -6,14 +6,17 @@ from sqlalchemy.orm import Session
 from app.core.config.settings import SECRET_KEY, ALGORITHM
 from app.user.infrastructure.repository import UserRepository
 from app.infrastructure.db.connection import getDb
+from typing import Optional
 
 # Crear una instancia de HTTPBearer
 security_scheme = HTTPBearer()
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+    credentials: Optional[HTTPAuthorizationCredentials] = Security(security_scheme),
     db: Session = Depends(getDb)
 ):
+    if credentials is None:
+        return None  # Usuario no autenticado
     token = credentials.credentials
     user_repository = UserRepository(db)
 

--- a/app/user/application/user_creation_use_case.py
+++ b/app/user/application/user_creation_use_case.py
@@ -6,7 +6,7 @@ from app.core.services.email_service import send_email
 from app.core.services.pin_service import generate_pin
 from app.user.infrastructure.repository import UserRepository
 from app.user.domain.exceptions import TooManyConfirmationAttempts
-from app.user.domain.schemas import UserCreate, UserInDB
+from app.user.domain.schemas import AdminUserCreate, UserCreate, UserInDB
 
 class UserCreationUseCase:
     def __init__(self, db: Session):
@@ -61,6 +61,24 @@ class UserCreationUseCase:
             # Manejar excepción (puede mejorarse con un sistema de logging)
             print(f"Error al crear la confirmación del usuario: {str(e)}")
             return False
+        
+    def create_user_by_admin(self, user_data: AdminUserCreate) -> User:
+        hashed_password = hash_password(user_data.password)
+        active_state_id = self.user_repository.get_active_user_state_id()
+        if not active_state_id:
+            raise ValueError("No se pudo encontrar el estado de usuario activo")
+        new_user = User(
+            nombre=user_data.nombre,
+            apellido=user_data.apellido,
+            email=user_data.email,
+            password=hashed_password,
+            state_id=active_state_id
+        )
+        created_user = self.user_repository.create_user(new_user)
+        # Asignar el rol especificado
+        self.user_repository.assign_role_to_user(created_user.id, user_data.role_id)
+        return created_user
+
 
     def send_confirmation_email(self, email: str, pin: str) -> bool:
         """Envía un correo electrónico con el PIN de confirmación."""

--- a/app/user/domain/schemas.py
+++ b/app/user/domain/schemas.py
@@ -16,6 +16,9 @@ class UserCreate(BaseModel):
         except ValueError as e:
             raise ValueError(str(e))
         
+class AdminUserCreate(UserCreate):
+    role_id: int
+
 class Confirmation(BaseModel):
     usuario_id: int
     pin: str = Field(..., min_length=1, max_length=64)

--- a/app/user/infrastructure/repository.py
+++ b/app/user/infrastructure/repository.py
@@ -242,6 +242,9 @@ class UserRepository:
     # Métodos relacionados con estados y roles
     def get_state_by_id(self, state_id: int):
         return self.db.query(EstadoUsuario).filter(EstadoUsuario.id == state_id).first()
+    
+    def get_role_by_id(self, role_id: int) -> Optional[Role]:
+        return self.db.query(Role).filter(Role.id == role_id).first()
         
     def get_active_user_state_id(self) -> Optional[int]:
         active_state = self.db.query(EstadoUsuario).filter(EstadoUsuario.nombre == "active").first()


### PR DESCRIPTION
# Descripción del cambio

Se solicitó modificar el endpoint de creación de usuarios para que los administradores pudieran crear usuarios asignándoles automáticamente un rol y un estado de activo. Sin embargo, esto implicaría añadir demasiadas responsabilidades a un único caso de uso. Por ello, se optó por crear un nuevo endpoint que gestionara esta funcionalidad de forma independiente, manteniendo separado el proceso de registro de usuarios por parte de los administradores del registro de usuarios por sí mismos.

# Enlace a la tarea de Jira

https://usco-team-y6acsy2v.atlassian.net/browse/AGROINSHT-148?atlOrigin=eyJpIjoiYTdjNGVjNWU3NzNmNGQwMThmYWRlYjJmZTkxNTY2YzUiLCJwIjoiaiJ9

# Tabla de estrategia de fusión

| Tipo de rama | Estrategia de fusión |
|--------------|---------------------|
| main/*    | Merge               |
| feature/*    | Squash and Merge    |
| fix/*        | Squash and Merge    |
| hotfix/*     | Squash and Merge    |